### PR TITLE
Feature ssl base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER David King <dsmk@bu.edu>
 RUN yum -y update \
   && yum -y install wget epel-release \
   && wget http://download.opensuse.org/repositories/security://shibboleth/CentOS_7/security:shibboleth.repo -P /etc/yum.repos.d \
-  && yum -y install httpd shibboleth.x86_64 dos2unix \
+  && yum -y install httpd mod_ssl shibboleth.x86_64 dos2unix \
   && rm /etc/shibboleth/sp-*.pem \
   && yum clean all
 
@@ -43,6 +43,7 @@ ENV SP_HANDLER_URL /Shibboleth.sso
 ENV SP_HOME_URL /
 
 EXPOSE 80
+EXPOSE 443
 
 # now we have our test SP configuration
 #COPY shibboleth /var/www/cgi-bin
@@ -57,6 +58,8 @@ COPY healthcheck /var/www/html/server/healthcheck
 ADD shibboleth-sp/ /etc/shibboleth/
 
 RUN chmod +x /var/www/cgi-bin/* && dos2unix /usr/bin/httpd-foreground /var/www/cgi-bin/printenv
+
+VOLUME /var/www/html
 
 # if we set the following variables then 
 CMD ["httpd-foreground"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # shib-sp-test
-Simple Shibboleth SP test
+
+
+Simple Shibboleth SP base image to be used by services that need authentication.
+
+As of December 2020 it is being used for phpbin {prod and non-prod} and static Non-WordPress Content Sites {non-prod}.
+
+The SSL support is designed to be used by backend servers so it uses it own self-signed certificates.
 
 ## How to build a set of key and certificates
 

--- a/test/sut/tests/base_server.bats
+++ b/test/sut/tests/base_server.bats
@@ -15,17 +15,15 @@ setup () {
 @test "base_server: Healthcheck (http)" {
   test_web http "$BUWEBHOST" /server/healthcheck
   assert_status 200
-  assert_backend healthcheck
   assert_contains OK
 }
 
 # This backend does not yet work on SSL connections
-#@test "base_server: Healthcheck (https)" {
-#  test_web https "$BUWEBHOST" /server/healthcheck
-#  assert_status 200
-#  assert_backend healthcheck
-#  assert_contains OK
-#}
+@test "base_server: Healthcheck (https)" {
+  test_web https "$BUWEBHOST" /server/healthcheck
+  assert_status 200
+  assert_contains OK
+}
 
 #@test "base_server: backend test (http)" {
 #  [ "x$TEST_BASE" = x ] && skip "only done when testing base images"


### PR DESCRIPTION
Simple Shibboleth SP base image to be used by services that need authentication.

As of December 2020 it is being used for phpbin {prod and non-prod} and static Non-WordPress Content Sites {non-prod}.

The SSL support is designed to be used by backend servers so it uses it own self-signed certificates.

Would you please add this to queue for Jan 2021.